### PR TITLE
Fix spec nss

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {hiccup/hiccup {:mvn/version "1.0.5"}
+        crate/crate {:mvn/version "0.2.4"}
+        viz-cljc/viz-cljc {:mvn/version "0.1.3" :exclusions [org.clojure/clojurescript org.clojure/clojure]}}
+
+ :aliases {:dev {:extra-deps {org.clojure/tools.trace {:mvn/version "0.7.10"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,8 @@
-(defproject specviz "0.2.4"
+(defproject specviz "0.2.5-SNAPSHOT"
   :description "Generate Graphviz images from Clojure specs"
   :url "https://github.com/jebberjeb/specviz"
   :license {:name "MIT"
-            :url ""}
-  :dependencies [[hiccup "1.0.5"]
-                 [crate "0.2.4"]
-                 [org.clojure/clojure "1.9.0-alpha17"]
-                 [org.clojure/test.check "0.9.0"]
-                 [viz-cljc "0.1.2"]]
+            :url "https://opensource.org/licenses/MIT"}
 
-  :source-paths ["src"])
+  :plugins [[lein-tools-deps "0.4.5"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn])

--- a/src/specviz/core.clj
+++ b/src/specviz/core.clj
@@ -90,11 +90,11 @@
                                     (first spec-form))))
 
 (s/def ::keys (s/cat
-                :keys #{'clojure.spec/keys}
+                :keys #{'clojure.spec.alpha/keys}
                 :parts (s/* (s/cat :type #{:req :opt :req-un :opt-un}
                                    :kws (s/every keyword? :kind vector?)))))
 
-(defmethod spec->graphviz-elements* 'clojure.spec/keys
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/keys
   [spec-form spec-keyword]
   (let [node-name (or (clean-name spec-keyword) (next-name))
         parts (:parts (s/conform ::keys spec-form))
@@ -138,7 +138,7 @@
                           nil))
      ::graphviz/shape "plaintext"}))
 
-(defmethod spec->graphviz-elements* 'clojure.spec/and
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/and
   [spec-form spec-keyword]
   (let [and-node (and-graphviz-node (next-name) (count (rest spec-form)))
         branches (map-indexed
@@ -161,7 +161,7 @@
    ::graphviz/label ""
    ::graphviz/shape "diamond"})
 
-(defmethod spec->graphviz-elements* 'clojure.spec/or
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/or
   [spec-form spec-keyword]
   (let [or-node (or-graphviz-node)
         or-pairs (->> spec-form rest (partition 2))
@@ -222,7 +222,7 @@
                       (range)))]
     (conj nodes table-node)))
 
-(defmethod spec->graphviz-elements* 'clojure.spec/every
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/every
   [spec-form spec-keyword]
   (if (not (coll? (second spec-form)))
     ;; TODO - factor this!
@@ -239,7 +239,7 @@
                           :ellipses-row true
                           :title-suffix "{...}")))
 
-(defmethod spec->graphviz-elements* 'clojure.spec/tuple
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/tuple
   [spec-form spec-keyword]
   (tabular-spec->graphviz-elements* (rest spec-form)
                                     spec-keyword
@@ -247,7 +247,7 @@
                                     :row-suffix " )"
                                     :row-prefix "( "))
 
-(defmethod spec->graphviz-elements* 'clojure.spec/nilable
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/nilable
   [spec-form spec-keyword]
   (spec->graphviz-elements `(s/or :nil nil?
                                   :not-nil ~@(rest spec-form))
@@ -255,27 +255,27 @@
 
 ;; Unsupported
 
-(defmethod spec->graphviz-elements* 'clojure.spec/multi-spec
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/multi-spec
   [spec-form spec-keyword]
   nil)
 
-(defmethod spec->graphviz-elements* 'clojure.spec/fspec
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/fspec
   [spec-form spec-keyword]
   nil)
 
-(defmethod spec->graphviz-elements* 'clojure.spec/*
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/*
   [spec-form spec-keyword]
   nil)
 
-(defmethod spec->graphviz-elements* 'clojure.spec/&
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/&
   [spec-form spec-keyword]
   nil)
 
-(defmethod spec->graphviz-elements* 'clojure.spec/cat
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/cat
   [spec-form spec-keyword]
   nil)
 
-(defmethod spec->graphviz-elements* 'clojure.spec/merge
+(defmethod spec->graphviz-elements* 'clojure.spec.alpha/merge
   [spec-form spec-keyword]
   nil)
 

--- a/src/specviz/graphviz.cljc
+++ b/src/specviz/graphviz.cljc
@@ -92,7 +92,7 @@
        (map render-graphviz)
        (apply str)))
 
-;; *** graphviz utility funcitons ***
+;; *** graphviz utility functions ***
 
 (let [id (atom 0)]
   (defn- next-id


### PR DESCRIPTION
The namespace was not correct for Clojure 1.10 and the new spec libraries.

This patch fixes them and adds `deps.edn` for easy local changes.